### PR TITLE
Beta release of version 1.0.1

### DIFF
--- a/aderisWiretap_Installers/Mac/aderisWiretap.pkg
+++ b/aderisWiretap_Installers/Mac/aderisWiretap.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef2da052b8c2edbc6e8d9b4641b9786a0cc18de001c1ee188884a896dfa7cf1a
-size 478671775

--- a/aderisWiretap_Installers/Ubuntu/aderisWiretap_1.1.0_amd64.deb
+++ b/aderisWiretap_Installers/Ubuntu/aderisWiretap_1.1.0_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62987f6de4599154df79e6cd43e5708a31fa13542351c667496996d145383175
-size 103845064

--- a/aderisWiretap_Installers/Windows/aderisWiretap Setup 1.0.1.exe
+++ b/aderisWiretap_Installers/Windows/aderisWiretap Setup 1.0.1.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:588c2394538e38f14388f7bb7f62cd622d0730c882eaad2a29a68ba3dc577fe0
+size 136710075

--- a/aderisWiretap_Installers/Windows/aderisWiretap Setup 1.0.1.exe
+++ b/aderisWiretap_Installers/Windows/aderisWiretap Setup 1.0.1.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:588c2394538e38f14388f7bb7f62cd622d0730c882eaad2a29a68ba3dc577fe0
-size 136710075

--- a/aderisWiretap_Installers/Windows/aderisWiretap_Setup _1.0.0.exe
+++ b/aderisWiretap_Installers/Windows/aderisWiretap_Setup _1.0.0.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e824b23356938f2193b947a1b7bce9b90b5e3c17c4c59d5360b587108642d5b
-size 136725798

--- a/aderisWiretap_Installers/Windows/aderisWiretap_Setup_1.0.1.exe
+++ b/aderisWiretap_Installers/Windows/aderisWiretap_Setup_1.0.1.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:588c2394538e38f14388f7bb7f62cd622d0730c882eaad2a29a68ba3dc577fe0
+size 136710075


### PR DESCRIPTION
**Version 1.0.1 for Windows - Aderis Wiretap Installer**

This release addresses several key improvements and fixes for the Windows installation process of Aderis Wiretap, version 1.0.1. The changes in this version include:

**New Features:**

1. Admin Access Warning: If the user does not have administrative privileges, a pop-up warning will be displayed:

![Screenshot (397)](https://github.com/user-attachments/assets/caefbb6d-864e-4001-915b-6134f487d2fb)

2. "Administrative privileges are required to run this installation. Please run as administrator."
3. This ensures users are informed that administrative rights are necessary for successful installation.
Architecture Detection: The installer now checks whether the system architecture is amd64 or x86_64. Based on this, it will correctly install the required Python version tailored to the system's architecture.

**Bug Fixes:**

1. Path Handling Fix: Fixed an issue with path handling during the installation. Previously, paths containing spaces were not properly quoted, causing execution errors. The script has been updated to ensure that paths containing spaces are correctly wrapped in double quotes, allowing the installer to run as expected without issues.

**Windows-Specific Enhancements:**

1. This update is specific to Windows and ensures smooth installation by handling the common administrative and path-related issues that were present in earlier versions.

This version aims to improve the overall installation experience on Windows by ensuring compatibility with various system configurations and simplifying the installation process.